### PR TITLE
Add version function to oca.client

### DIFF
--- a/oca/__init__.py
+++ b/oca/__init__.py
@@ -120,6 +120,12 @@ class Client(object):
             raise OpenNebulaException(data)
         return data
 
+    def version(self):
+        '''
+        Get the version of the connected OpenNebula server.
+        '''
+        return self.call('system.version')
+
 __all__ = [Client, OpenNebulaException, Host, HostPool, VirtualMachine,
         VirtualMachinePool, User, UserPool,
         Image, ImagePool, VirtualNetwork, VirtualNetworkPool,


### PR DESCRIPTION
The function calls the one.system.version XML-RPC method and returns the
OpenNebula version of the connected server.

Can be used to check if the client can connect properly (user/pass and
url correct)