### PR TITLE
Run tox in travis-ci; add coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
 python:
  - "2.7"
-script: python setup.py test
+install:
+  - pip install tox
+script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = py26,py27,pypy
+envlist = py27
 [testenv]
 deps=nose
     mock
     coverage
-commands=nosetests
+commands=nosetests --with-coverage --cover-package=oca


### PR DESCRIPTION
Run tox instead of "python setup.py test"; only test with Python 2.7 for now