### PR TITLE
ONe 4.14; update virtualmachine class

### DIFF
--- a/oca/tests/test_virtualmachine.py
+++ b/oca/tests/test_virtualmachine.py
@@ -28,10 +28,6 @@ class TestVirtualMachine:
         assert vm['stime'] == '1277375180'
         assert vm['etime'] == '0'
         assert vm['deploy_id'] == 'dummy'
-        assert vm['memory'] == '512'
-        assert vm['cpu'] == '1'
-        assert vm['net_tx'] == '12345'
-        assert vm['net_rx'] == '0'
 
     def test_acces_items_not_using_brackets(self):
         vm = oca.VirtualMachine(self.xml, self.client)
@@ -43,10 +39,6 @@ class TestVirtualMachine:
         assert vm.stime == '1277375180'
         assert vm.etime == '0'
         assert vm.deploy_id == 'dummy'
-        assert vm.memory == '512'
-        assert vm.cpu == '1'
-        assert vm.net_tx == '12345'
-        assert vm.net_rx == '0'
 
     @raises(IndexError)
     def test_raise_exception_Index_Error_when_using_brackets(self):
@@ -64,10 +56,6 @@ class TestVirtualMachine:
         assert vm.stime == 1277375180
         assert vm.etime == 0
         assert vm.deploy_id == 'dummy'
-        assert vm.memory == 512
-        assert vm.cpu == 1
-        assert vm.net_tx == 12345
-        assert vm.net_rx == 0
         assert isinstance(vm.template, oca.pool.Template)
 
     def test_allocate(self):

--- a/oca/vm.py
+++ b/oca/vm.py
@@ -92,10 +92,6 @@ class VirtualMachine(PoolElement):
         'stime':         int,
         'etime':         int,
         'deploy_id':     extractString,
-        'memory':        int,
-        'cpu':           int,
-        'net_tx':        int,
-        'net_rx':        int,
         'template':      ['TEMPLATE', Template, ['NIC', 'DISK']],
         'user_template': ['USER_TEMPLATE', Template],
         'history_records':  ['HISTORY_RECORDS', lambda x: [History(i)


### PR DESCRIPTION
* Some xml elements moved from top-level &lt;VM&gt; to the &lt;MONITORING&gt;
  section (cpu, memory, net_rx, net_tx)