### PR TITLE
fix for VirtualMachinePool.info()  error

### DIFF
--- a/oca/pool.py
+++ b/oca/pool.py
@@ -52,7 +52,8 @@ class XMLElement(object):
         self.xml = xml
 
     def _initialize_xml(self, xml, root_element):
-        self.xml = ET.fromstring(xml)
+        hidden_character=u"\u200b"
+        self.xml = ET.fromstring(xml.replace(hidden_character,""))
         if self.xml.tag != root_element.upper():
             self.xml = None
         self._convert_types()


### PR DESCRIPTION
Workaround for handling utf-8 hidden line break  character. Solves #17