### PR TITLE
Add Leases and Hold/Release functions

### DIFF
--- a/oca/image.py
+++ b/oca/image.py
@@ -12,6 +12,7 @@ class Image(PoolElement):
         'publish'  : 'image.publish',
         'chown'    : 'image.chown',
         'persistent'  : 'image.persistent',
+        'clone'    : 'image.clone',
     }
 
     XML_TYPES = {
@@ -143,6 +144,15 @@ class Image(PoolElement):
             New group id. Set to -1 to leave current value
         '''
         self.client.call(self.METHODS['chown'], self.id, uid, gid)
+
+    def clone(self, name=''):
+        '''
+        Makes a clone of a given image
+        ``name```
+            Name of the target image
+        '''
+        self.client.call(self.METHODS['clone'], self.id, name)
+
 
     @property
     def str_state(self):

--- a/oca/template.py
+++ b/oca/template.py
@@ -11,6 +11,7 @@ class VmTemplate(PoolElement):
         'publish'  : 'template.publish',
         'chown'    : 'template.chown',
         'instantiate' : 'template.instantiate',
+        'clone'    : 'template.clone',
     }
 
     XML_TYPES = {
@@ -44,14 +45,16 @@ class VmTemplate(PoolElement):
         super(VmTemplate, self).__init__(xml, client)
         self.id = self['ID'] if self['ID'] else None
 
-    def update(self, template):
+    def update(self, template, update_type=0):
         '''
         Replaces the template contents.
 
         ``template``
             The new template contents.
+        ``update_type``
+            Update type: 0: replace the whole template. 1: Merge new template with the existing one.
         '''
-        self.client.call(VmTemplate.METHODS['update'], self.id, template)
+        self.client.call(VmTemplate.METHODS['update'], self.id, template, update_type)
 
     def publish(self):
         '''
@@ -84,6 +87,14 @@ class VmTemplate(PoolElement):
             name of the VM instance
         '''
         self.client.call(VmTemplate.METHODS['instantiate'], self.id, name)
+
+    def clone(self, name=''):
+        '''
+        Creates a clone of template
+        ``name``
+            name of a target template
+        '''
+        self.client.call(VmTemplate.METHODS['clone'], self.id, name)
 
     def __repr__(self):
         return '<oca.VmTemplate("%s")>' % self.name

--- a/oca/tests/test_template.py
+++ b/oca/tests/test_template.py
@@ -27,7 +27,7 @@ class TestVmTemplate:
         template = oca.VmTemplate(self.xml, self.client)
         template.update('name=b')
         self.client.call.assert_called_once_with('template.update',
-                                                            '1', 'name=b')
+                                                            '1', 'name=b', 0)
 
     def test_publish(self):
         self.client.call = Mock()

--- a/oca/vn.py
+++ b/oca/vn.py
@@ -1,11 +1,34 @@
 # -*- coding: UTF-8 -*-
 from pool import XMLElement, Pool, PoolElement, Template
 
+class Lease(XMLElement):
+    XML_TYPES = {
+            'ip' : str,
+            'mac' : str,
+    }
+
+    def __init__(self, xml):
+        super(Lease, self).__init__(xml)
+        self._convert_types()
+
+class LeasesList(list):
+    def __init__(self, xml):
+        if xml is None:
+            return
+        self.xml = xml
+        for element in self.xml:
+            self.append(self._factory(element))
+
+    def _factory(self, xml):
+        v = Lease(xml)
+        v._convert_types()
+        return v
 
 class AddressRange(XMLElement):
     XML_TYPES = {
             'id'   : ["AR_ID", lambda xml: int(xml.text)],
             'size' : int,
+            'leases': ['LEASES', LeasesList],
             #'template' : ['TEMPLATE', Template],
     }
 
@@ -125,10 +148,13 @@ class VirtualNetworkPool(Pool):
             'info' : 'vnpool.info',
     }
 
-    def __init__(self, client):
+    def __init__(self, client, preload_info=False):
+        self.preload_info = preload_info
         super(VirtualNetworkPool, self).__init__('VNET_POOL', 'VNET', client)
 
     def _factory(self, xml):
         v = VirtualNetwork(xml, self.client)
         v._convert_types()
+        if self.preload_info:
+            v.info()
         return v

--- a/oca/vn.py
+++ b/oca/vn.py
@@ -32,6 +32,8 @@ class VirtualNetwork(PoolElement):
         'delete'   : 'vn.delete',
         'publish'  : 'vn.publish',
         'chown'    : 'vn.chown',
+        'hold'     : 'vn.hold',
+        'release'  : 'vn.release',
     }
 
     XML_TYPES = {
@@ -92,6 +94,28 @@ class VirtualNetwork(PoolElement):
         New group id. Set to -1 to leave current value
         '''
         self.client.call(self.METHODS['chown'], self.id, uid, gid)
+
+    def release(self, ip):
+        '''
+        Releases given IP
+
+        Arguments
+
+        ``ip``
+        IP to realse
+        '''
+        self.client.call(self.METHODS['release'], self.id, 'LEASES=[IP={}]'.format(ip))
+
+    def hold(self, ip):
+        '''
+        Holds given IP
+
+        Arguments
+
+        ``ip``
+        IP to hold
+        '''
+        self.client.call(self.METHODS['hold'], self.id, 'LEASES=[IP={}]'.format(ip))
 
     def __repr__(self):
         return '<oca.VirtualNetwork("%s")>' % self.name


### PR DESCRIPTION
Hi,
While using OpenNebula we deadly needed to able to get current IP leases and hold/release IPs.

While hold/release functions are quite easy to implement the lease list was a problem. The lease list only appears in `VNET` specification and not `VNET_POOL`. So in order to have that lease we need to make a separate call *info* call for each VNET.

My solution isn't super great - I've just added a flag depending on which we either retrieve info for each `VNET` and fill the lease list or just leave it empty.