### PR TITLE
Image.allocate is missing parameter datastore which is required.

### DIFF
--- a/oca/image.py
+++ b/oca/image.py
@@ -66,7 +66,7 @@ class Image(PoolElement):
     ELEMENT_NAME = 'IMAGE'
 
     @staticmethod
-    def allocate(client, template):
+    def allocate(client, template,datastore):
         '''
         Allocates a new image in OpenNebula
 
@@ -77,8 +77,10 @@ class Image(PoolElement):
 
         ``template``
            a string containing the template of the image
+        ``datastore``
+          the datastore id where the image is to be allocated
         '''
-        image_id = client.call(Image.METHODS['allocate'], template)
+        image_id = client.call(Image.METHODS['allocate'], template,datastore)
         return image_id
 
     def __init__(self, xml, client):

--- a/oca/image.py
+++ b/oca/image.py
@@ -66,7 +66,7 @@ class Image(PoolElement):
     ELEMENT_NAME = 'IMAGE'
 
     @staticmethod
-    def allocate(client, template,datastore):
+    def allocate(client, template, datastore):
         '''
         Allocates a new image in OpenNebula
 
@@ -80,7 +80,7 @@ class Image(PoolElement):
         ``datastore``
           the datastore id where the image is to be allocated
         '''
-        image_id = client.call(Image.METHODS['allocate'], template,datastore)
+        image_id = client.call(Image.METHODS['allocate'], template, datastore)
         return image_id
 
     def __init__(self, xml, client):

--- a/oca/tests/test_image.py
+++ b/oca/tests/test_image.py
@@ -23,7 +23,7 @@ class TestImage(unittest.TestCase):
 
     def test_allocate(self):
         self.client.call = Mock(return_value=2)
-        assert oca.Image.allocate(self.client, IMAGE_TEMPLATEi, DEFAULT_IMG_DATASTORE) == 2
+        assert oca.Image.allocate(self.client, IMAGE_TEMPLATE, DEFAULT_IMG_DATASTORE) == 2
 
     def test_enable(self):
         self.client.call = Mock(return_value='')

--- a/oca/tests/test_image.py
+++ b/oca/tests/test_image.py
@@ -13,6 +13,7 @@ PATH          = /home/cloud/images/ubuntu-desktop/disk.0
 PUBLIC        = YES
 DESCRIPTION   = "Ubuntu 10.04 desktop for students."'''
 
+DEFAULT_IMG_DATASTORE = 1
 
 class TestImage(unittest.TestCase):
     def setUp(self):
@@ -22,7 +23,7 @@ class TestImage(unittest.TestCase):
 
     def test_allocate(self):
         self.client.call = Mock(return_value=2)
-        assert oca.Image.allocate(self.client, IMAGE_TEMPLATE) == 2
+        assert oca.Image.allocate(self.client, IMAGE_TEMPLATEi, DEFAULT_IMG_DATASTORE) == 2
 
     def test_enable(self):
         self.client.call = Mock(return_value='')


### PR DESCRIPTION
Without this parameter, Image.allocate gives xmlrpclib.Fault: <Fault -501: 'Not enough parameters'>