### PR TITLE
Allow template instantiation with extra template attributes

### DIFF
--- a/oca/template.py
+++ b/oca/template.py
@@ -79,14 +79,18 @@ class VmTemplate(PoolElement):
         '''
         self.client.call(VmTemplate.METHODS['chown'], self.id, uid, gid)
 
-    def instantiate(self, name=''):
+    def instantiate(self, name='', pending=False, extra_template=''):
         '''
         Creates a VM instance from a VmTemplate
 
         ``name``
             name of the VM instance
+        ``pending``
+            False to create the VM on pending (default), True to create it on hold.
+        ``extra_template``
+            A string containing an extra template to be merged with the one being instantiated
         '''
-        self.client.call(VmTemplate.METHODS['instantiate'], self.id, name)
+        self.client.call(VmTemplate.METHODS['instantiate'], self.id, name, pending, extra_template)
 
     def __repr__(self):
         return '<oca.VmTemplate("%s")>' % self.name

--- a/oca/tests/test_template.py
+++ b/oca/tests/test_template.py
@@ -56,14 +56,28 @@ class TestVmTemplate(unittest.TestCase):
         template = oca.VmTemplate(self.xml, self.client)
         template.instantiate()
         self.client.call.assert_called_once_with('template.instantiate',
-                                                            '1', '')
+                                                            '1', '', False, '')
 
     def test_instantiate_with_custom_name(self):
         self.client.call = Mock()
         template = oca.VmTemplate(self.xml, self.client)
         template.instantiate('asd')
         self.client.call.assert_called_once_with('template.instantiate',
-                                                            '1', 'asd')
+                                                            '1', 'asd', False, '')
+
+    def test_instantiate_with_default_name_and_context(self):
+        self.client.call = Mock()
+        template = oca.VmTemplate(self.xml, self.client)
+        template.instantiate('', False, 'VCPU=4')
+        self.client.call.assert_called_once_with('template.instantiate',
+                                                            '1', '', False, 'VCPU=4')
+
+    def test_instantiate_with_custom_name_and_context(self):
+        self.client.call = Mock()
+        template = oca.VmTemplate(self.xml, self.client)
+        template.instantiate('asd', False, 'VCPU=4')
+        self.client.call.assert_called_once_with('template.instantiate',
+                                                            '1', 'asd', False, 'VCPU=4')
 
     def test_repr(self):
         self.client.call = Mock()


### PR DESCRIPTION
Template instantiation allows extra contex attributes to be passed:
http://docs.opennebula.org/4.12/integration/system_interfaces/api.html#one-template-instantiate

I'd like to submit this so you can pass extra templates attributes (or even instantiate a template as "pending".