### PR TITLE
Add support for the image chmod method

### DIFF
--- a/oca/image.py
+++ b/oca/image.py
@@ -10,6 +10,7 @@ class Image(PoolElement):
         'update': 'image.update',
         'enable': 'image.enable',
         'publish': 'image.publish',
+        'chmod': 'image.chmod',
         'chown': 'image.chown',
         'persistent': 'image.persistent',
         'clone': 'image.clone',
@@ -151,6 +152,34 @@ class Image(PoolElement):
             New group id. Set to -1 to leave current value
         """
         self.client.call(self.METHODS['chown'], self.id, uid, gid)
+
+    def chmod(self, owner_u, owner_m, owner_a, group_u, group_m, group_a, other_u, other_m, other_a):
+        """
+        Changes the permission bits
+
+        Arguments
+
+        ``owner_u``
+            User USE bit. Set to -1 to leave current value
+        ``owner_m``
+            User MANAGE bit. Set to -1 to leave current value
+        ``owner_a``
+            User ADMIN bit. Set to -1 to leave current value
+        ``group_u``
+            Group USE bit. Set to -1 to leave current value
+        ``group_m``
+            Group MANAGE bit. Set to -1 to leave current value
+        ``group_a``
+            Group ADMIN bit. Set to -1 to leave current value
+        ``other_u``
+            Other USE bit. Set to -1 to leave current value
+        ``other_m``
+            Other MANAGE bit. Set to -1 to leave current value
+        ``other_a``
+            Other ADMIN bit. Set to -1 to leave current value
+        """
+        self.client.call(self.METHODS['chmod'], self.id, owner_u, owner_m, owner_a, group_u, group_m, group_a, other_u,
+                         other_m, other_a)
 
     def clone(self, name='', datastore_id=-1):
         """

--- a/oca/tests/test_image.py
+++ b/oca/tests/test_image.py
@@ -100,3 +100,10 @@ class TestImage(unittest.TestCase):
         h.chown(10, 10)
         self.client.call.assert_called_once_with('image.chown',
                                                  '1', 10, 10)
+
+    def test_chmod(self):
+        self.client.call = Mock(return_value='')
+        h = oca.Image(self.xml, self.client)
+        h.chmod(1, 0, 0, -1, -1, -1, -1, -1, -1)
+        self.client.call.assert_called_once_with('image.chmod',
+                                                 '1', 1, 0, 0, -1, -1, -1, -1, -1, -1)


### PR DESCRIPTION
Variable names 'inspired' in https://github.com/OpenNebula/one/blob/master/src/oca/ruby/opennebula/image.rb#L189

I had also the idea to implement some sort of octal mode, but I think it may be a job for the application using the bindings to do the translation