### PR TITLE
The template.instantiate method should return the new vm id

### DIFF
--- a/oca/template.py
+++ b/oca/template.py
@@ -90,7 +90,7 @@ class VmTemplate(PoolElement):
         ``extra_template``
             A string containing an extra template to be merged with the one being instantiated
         """
-        self.client.call(VmTemplate.METHODS['instantiate'], self.id, name, pending, extra_template)
+        return self.client.call(VmTemplate.METHODS['instantiate'], self.id, name, pending, extra_template)
 
     def __repr__(self):
         return '<oca.VmTemplate("%s")>' % self.name

--- a/oca/tests/test_template.py
+++ b/oca/tests/test_template.py
@@ -52,30 +52,30 @@ class TestVmTemplate(unittest.TestCase):
                                                  '1', 2, 3)
 
     def test_instantiate_with_default_name(self):
-        self.client.call = Mock()
+        self.client.call = Mock(return_value=4)
         template = oca.VmTemplate(self.xml, self.client)
-        template.instantiate()
+        assert template.instantiate() == 4
         self.client.call.assert_called_once_with('template.instantiate',
                                                  '1', '', False, '')
 
     def test_instantiate_with_custom_name(self):
-        self.client.call = Mock()
+        self.client.call = Mock(return_value=5)
         template = oca.VmTemplate(self.xml, self.client)
-        template.instantiate('asd')
+        assert template.instantiate('asd') == 5
         self.client.call.assert_called_once_with('template.instantiate',
                                                  '1', 'asd', False, '')
 
     def test_instantiate_with_default_name_and_context(self):
-        self.client.call = Mock()
+        self.client.call = Mock(return_value=6)
         template = oca.VmTemplate(self.xml, self.client)
-        template.instantiate('', False, 'VCPU=4')
+        assert template.instantiate('', False, 'VCPU=4') == 6
         self.client.call.assert_called_once_with('template.instantiate',
                                                  '1', '', False, 'VCPU=4')
 
     def test_instantiate_with_custom_name_and_context(self):
-        self.client.call = Mock()
+        self.client.call = Mock(return_value=7)
         template = oca.VmTemplate(self.xml, self.client)
-        template.instantiate('asd', False, 'VCPU=4')
+        assert template.instantiate('asd', False, 'VCPU=4') == 7
         self.client.call.assert_called_once_with('template.instantiate',
                                                  '1', 'asd', False, 'VCPU=4')
 


### PR DESCRIPTION
`template.instantiate` returns the new virtual machine ID. There's no way to tell which vm is the new created one without this ID.