### PR TITLE
Add missing OpenNebula 5 host state

### DIFF
--- a/oca/host.py
+++ b/oca/host.py
@@ -24,8 +24,10 @@ class Host(PoolElement):
     MONITORING_ERROR = 5  # Currently monitoring, previously ERROR
     MONITORING_INIT = 6  # Currently monitoring, previously initialized
     MONITORING_DISABLED = 7  # Currently monitoring, previously DISABLED
+    OFFLINE = 8  # OpenNebula 5 allows hosts to be set offline
     HOST_STATES = ['INIT', 'MONITORING_MONITORED', 'MONITORED', 'ERROR', 'DISABLED',
-                   'MONITORING_ERROR', 'MONITORING_INIT', 'MONITORING_DISABLED']
+                   'MONITORING_ERROR', 'MONITORING_INIT', 'MONITORING_DISABLED',
+                   'OFFLINE']
 
     SHORT_HOST_STATES = {
         'INIT': 'on',
@@ -36,6 +38,7 @@ class Host(PoolElement):
         'MONITORING_ERROR': 'on',
         'MONITORING_INIT': 'on',
         'MONITORING_DISABLED': 'on',
+        'OFFLINE': 'off',
     }
 
     XML_TYPES = {

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 import os
 import sys
 
-__version__ = '4.15.0a1'
+__version__ = '4.15.1'
 
 
 # borrowed from Pylons project


### PR DESCRIPTION
OpenNebula 5 introduced the possibility to set hosts 'offline'. This state is missing in the library and results in a stacktrace when encountered.

Referenced here:
http://docs.opennebula.org/5.8/operation/references/host_states.html#list-of-states