### PR TITLE
Fix compatibility issues in RPC call wrapper.

### DIFF
--- a/oca/__init__.py
+++ b/oca/__init__.py
@@ -117,16 +117,21 @@ class Client(object):
         try:
             func = getattr(self.server.one, function)
             ret = func(self.one_auth, *args)
-            try:
-                is_success, data, return_code = ret
-            except ValueError:
-                data = ''
-                is_success = False
         except socket.error as e:
-            # connection error
+            #connection error
             raise e
+        if len(ret) == 3:
+            is_success, data, return_code = ret
+        elif len(ret) == 4:
+            is_success, data, return_code, _ = ret
+        else:
+            raise OpenNebulaException(
+                "Unexpected return value from `%s`: %r"
+                % (function, ret))
         if not is_success:
-            raise OpenNebulaException(data)
+            raise OpenNebulaException(
+                "OpenNebula RPC call `%s` failed with return code %d: %s"
+                % (function, return_code, data))
         return data
 
     def version(self):


### PR DESCRIPTION
This fixes a few spurious errors I've found while using `python-oca`
with the Ansible module `one_vm`:

* The `except socket.error, e` syntax is deprecated since long and has
  been removed in Py3.

* On failure, ONE RPC seems to return a 4-tuple with the error message
  in position 1 and the constant `-1` in position 3.  This would have
  generated a `ValueError` which discarded the error message,
  obscuring important information.

* In general, try to be more verbose and precise in reporting errors
  to the caller.