### PR TITLE
Fix `coding:` line to be compatible with Emacs.

### DIFF
--- a/oca/__init__.py
+++ b/oca/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import http.client
 import os
 import re

--- a/oca/acl.py
+++ b/oca/acl.py
@@ -1,1 +1,1 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-

--- a/oca/cluster.py
+++ b/oca/cluster.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from .pool import Pool, PoolElement, Template, extractString
 
 

--- a/oca/datastore.py
+++ b/oca/datastore.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from .pool import Pool, PoolElement, Template, extractString
 
 

--- a/oca/exceptions.py
+++ b/oca/exceptions.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 
 
 class OpenNebulaException(Exception):

--- a/oca/group.py
+++ b/oca/group.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from .pool import Pool, PoolElement, Template, extractString
 
 

--- a/oca/host.py
+++ b/oca/host.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from .pool import Pool, PoolElement, Template, extractString
 
 

--- a/oca/image.py
+++ b/oca/image.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from .pool import Pool, PoolElement, Template, extractString
 
 

--- a/oca/pool.py
+++ b/oca/pool.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import xml.etree.ElementTree as ET
 
 from .exceptions import OpenNebulaException

--- a/oca/template.py
+++ b/oca/template.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from .pool import Pool, PoolElement, Template
 
 

--- a/oca/tests/test_client.py
+++ b/oca/tests/test_client.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import socket
 import unittest

--- a/oca/tests/test_cluster.py
+++ b/oca/tests/test_cluster.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_clusterpool.py
+++ b/oca/tests/test_clusterpool.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_datastore.py
+++ b/oca/tests/test_datastore.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_datastore_pool.py
+++ b/oca/tests/test_datastore_pool.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_group.py
+++ b/oca/tests/test_group.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_group_pool.py
+++ b/oca/tests/test_group_pool.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_host.py
+++ b/oca/tests/test_host.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_host_pool.py
+++ b/oca/tests/test_host_pool.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_image.py
+++ b/oca/tests/test_image.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_image_pool.py
+++ b/oca/tests/test_image_pool.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_template.py
+++ b/oca/tests/test_template.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_template_pool.py
+++ b/oca/tests/test_template_pool.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_user.py
+++ b/oca/tests/test_user.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_user_pool.py
+++ b/oca/tests/test_user_pool.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_virtual_network.py
+++ b/oca/tests/test_virtual_network.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_virtual_network_pool.py
+++ b/oca/tests/test_virtual_network_pool.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_virtualmachine.py
+++ b/oca/tests/test_virtualmachine.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/tests/test_virtualmachine_pool.py
+++ b/oca/tests/test_virtualmachine_pool.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 import os
 import unittest
 

--- a/oca/user.py
+++ b/oca/user.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from .pool import Pool, PoolElement, Template, extractString, XMLElement
 
 

--- a/oca/vm.py
+++ b/oca/vm.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from .pool import Pool, PoolElement, Template, extractString
 
 

--- a/oca/vn.py
+++ b/oca/vn.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from .pool import XMLElement, Pool, PoolElement, Template, extractString
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from setuptools import setup
 import setuptools
 import os


### PR DESCRIPTION
Emacs complains that `UTF-8` (all uppercase) is not a valid name of a
coding system:

    Warning (mule): Invalid coding system ‘UTF-8’ is specified
    for the current buffer/file by the :coding tag.
    It is highly recommended to fix it before writing to a file.

Using the lowercase version solves the problem.